### PR TITLE
add items api by ActiveStorage

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -1,0 +1,82 @@
+$(document).on('turbolinks:load', ()=> {
+
+  const buildPreview = (src, index)=> {
+    const html = `<div class='js_item-preview' data-index=${index}>
+                    <img src=${src} height='100' width='100'>
+                    <div class='btn_wrapper'>
+                      <label for="file${index}" class='js_item-edit'>編集</label>
+                      <span class='js_item-delete' data-index="${index}">削除</span>
+                    </div>
+                  </div>`
+    return html;
+  }
+
+  const removePhotoes = deleteBtn => {
+    const preview = deleteBtn.parentNode.parentNode;
+    const targetIndex = deleteBtn.dataset.index;
+    const input = document.querySelector(`.js_item-file[data-index="${targetIndex}"]`);
+    removeIds.push(input.dataset.id);
+    input.parentNode.removeChild(input);
+    preview.parentNode.removeChild(preview);
+  }
+
+  const itemFiles = document.querySelectorAll('.js_item-file');
+  const lastIndex = itemFiles.length;
+  const newLabel = document.querySelector('.js_item-label');
+  const itemForm = document.querySelector('.js_item-form');
+  const removeIds = []
+
+  // js_item-file の数を新規画像追加用のindexに使う
+  itemFiles[itemFiles.length - 1].dataset.index = lastIndex;
+  itemFiles[itemFiles.length - 1].setAttribute('id', `file${lastIndex}`);
+  newLabel.setAttribute('for', `file${lastIndex}`);
+
+  // 画像入力時の処理
+  $('.photo-inputs').on('change', '.js_item-file', function(e){
+    // 変更があったinputのdata-indexを取得
+    const targetIndex = Number(this.dataset.index);
+    // キャンセルした場合、targetIndexの削除ボタンを押したことにする
+    if (e.target.files.length === 0) {
+      removePhotoes(document.querySelector(`.js_item-delete[data-index="${targetIndex}"]`));
+      return;
+    }
+    const blobURL = URL.createObjectURL(e.target.files[0]);
+    // プレビューがあったら
+    if (preview = document.querySelector(`.js_item-preview[data-index="${targetIndex}"]`)) {
+      // imgタグのsrcを更新する
+      preview.firstElementChild.setAttribute('src', blobURL);
+      // 削除用の配列にdata-idを入れる
+      removeIds.push(this.dataset.id);
+      console.log(removeIds)
+    } else {
+      // input欄を追加し、labelを書き換え、プレビューを追加
+      document.querySelector('.photo-inputs').insertAdjacentHTML("beforeend", `<input name="item[photoes][]" class="js_item-file" type="file" id="file${targetIndex + 1}" data-index="${targetIndex + 1}">`);
+      newLabel.setAttribute('for', `file${targetIndex + 1}`);
+      newLabel.insertAdjacentHTML('beforebegin', buildPreview(blobURL, targetIndex));
+      if (document.querySelectorAll('.js_item-preview').length === 10) {
+        newLabel.style.display = 'none';
+      }
+    }
+  });
+
+  // 削除ボタン押下時の処理
+  $('.previews').on('click', '.js_item-delete', function() {
+    removePhotoes(this);
+    if (document.querySelectorAll('.js_item-preview').length < 10) {
+      newLabel.style.display = 'flex';
+    }
+  });
+
+  // 送信前にpurgeするべき画像id用のinputを差し込む
+  itemForm.addEventListener('submit', function(e) {
+    e.preventDefault();
+    // removeIdsのfalsyを排除し、Set型にして重複を削除
+    const removeIdSet = new Set(removeIds.filter(v => v));
+    if (removeIdSet.size !== 0) {
+      removeIdSet.forEach( (ele) => {
+        itemForm.insertAdjacentHTML('beforeend', `<input type="hidden" name="item[remove_ids][]" value="${ele}">`);
+      });
+    }
+    itemForm.submit();
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,5 @@
 @import 'products';
+
+* {
+  list-style: none;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
   # GET /items
   # GET /items.json
   def index
-    @items = Item.with_attached_images
+    @items = Item.with_attached_photoes
   end
 
   # GET /items/1
@@ -35,7 +35,10 @@ class ItemsController < ApplicationController
   # PATCH/PUT /items/1
   # PATCH/PUT /items/1.json
   def update
-    if @item.update
+    if @item.update(item_params)
+      @item.photoes.each do |photo|
+        photo.purge if params[:item][:remove_ids]&.include?(photo.id.to_s)
+      end
       redirect_to @item, notice: 'Item was successfully updated.'
     else
       render :edit
@@ -55,11 +58,11 @@ class ItemsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_item
-      @item = Item.with_attached_images.find(params[:id])
+      @item = Item.with_attached_photoes.find(params[:id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def item_params
-      params.require(:item).permit(:name, images: [])
+      params.require(:item).permit(:name, photoes: [])
     end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  has_many_attached :images
-  validates :images, presence: true
+  has_many_attached :photoes
+  validates :photoes, presence: true
 
 end

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @item, local: true do |f|
+= form_for @item, local: true, html: { class: 'js_item-form' } do |f|
   - if @item.errors.any?
     #error_explanation
       %h2= "#{pluralize(@item.errors.count, "error")} prohibited this item from being saved:"
@@ -12,14 +12,17 @@
   .field
     .previews
       - if @item.persisted?
-        - @item.images.each_with_index do |image, i|
-          .preview{"data-index" => i}
-            = image_tag image, width: "100", height: '100', data: {index: i}
-            = label_tag :image, '編集', for: "product_images_attributes_#{i}_image"
-            .delete-btn.js-remove{"data-index" => i} 削除
-      = label_tag :image, "ドラッグ＆ドロップ", class: "js-file_label previews__new-label"
-    = f.label :images
-    = f.file_field :images, multiple: true, class: 'js-item-file'
-    .item_image_input
+        - @item.photoes.each.with_index(1) do |photo,i|
+          .js_item-preview{ data: {index: i} }
+            = image_tag photo, height: 100, width: 100
+            .btn_wrapper
+              %label.js_item-edit{for: "file#{i}"} 編集
+              %span.js_item-delete{data: {index: i}} 削除
+      = f.label :photoes, "ドラッグ＆ドロップ", class: "js_item-label previews__new-label"
+    .photo-inputs
+      - if @item.persisted?
+        - @item.photoes.each.with_index(1) do |photo,i|
+          = f.file_field :photoes, name: 'item[photoes][]', class: 'js_item-file', data: {index: i, id: photo.id }, id: "file#{i}"
+      = f.file_field :photoes, name: 'item[photoes][]', class: 'js_item-file'
   .actions
     = f.submit 'Save'

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -13,7 +13,7 @@
       %tr
         %td= item.name
         %td
-          = image_tag item.images.first, width: "100", height: '100'
+          = image_tag item.photoes.first, width: "100", height: '100'
         %td= link_to 'Show', item
         %td= link_to 'Edit', edit_item_path(item)
         %td= link_to 'Destroy', item, method: :delete, data: { confirm: 'Are you sure?' }

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -4,9 +4,9 @@
   %b Name:
   = @item.name
 
-%ul
-  - @item.images.each do |image|
-    %li= image_tag image, width: "100", height: '100'
+%ul{style: 'display: flex;'}
+  - @item.photoes.each do |photo|
+    %li= image_tag photo, width: "100", height: '100'
 = link_to 'Edit', edit_item_path(@item)
 \|
 = link_to 'Back', items_path


### PR DESCRIPTION
# WHAT
ActiveStorageを用いた商品のCRUD機能を実装した

# WHY
carrierwave及びActiveStorageの実装をどちらも経験しておくことで受講生対応をスムーズに行うため

# HOW
Itemモデルを作成し、photoesというアタッチメント名で画像のアップロードを実装した。
fileのinputにattachmentのidを持たせ、削除or画像変更時にJSの配列removeIdsとして保持しておき、更新時にparamsに追加することで削除すべきレコードをコントローラで特定できるようにしている。